### PR TITLE
fix: 新用户第一次登陆没有介绍视频

### DIFF
--- a/skel/.config/autostart/dde-first-run.desktop
+++ b/skel/.config/autostart/dde-first-run.desktop
@@ -9,6 +9,6 @@ TryExec=/usr/libexec/dde-first-run
 Terminal=false
 Type=Application
 Categories=
-OnlyShowIn=Deepin;
+OnlyShowIn=DDE
 #X-GNOME-AutoRestart=true
 NoDisplay=true


### PR DESCRIPTION
Desktop文件中OnlyShowIn应该包含 DDE 作为当前桌面环境的名称

Log: 修复新用户第一次登陆没有介绍视频的问题
Influence: dde-introduction正常启动