### PR TITLE
fix: dde-file-manager not adaptor to AM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-default-settings (2024.04.23) unstable; urgency=medium
+
+  * make dde-file-manager first launched by AM
+
+ -- tsic404 <liuheng@deepin.org>  Tue, 23 Apr 2024 17:03:46 +0800
+
 deepin-default-settings (2024.04.22) unstable; urgency=medium
 
   * Fix #8101

--- a/etc.d/xdg/autostart/dde-file-manager.desktop
+++ b/etc.d/xdg/autostart/dde-file-manager.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Actions=new-window;
+Categories=Utility;
+Comment=Browse the file system
+Exec=/usr/bin/dde-file-manager -d
+GenericName=File Manager
+Icon=dde-file-manager
+MimeType=inode/directory;
+Name=Deepin File Manager
+StartupNotify=true
+Terminal=false
+Type=Application
+Version=1.0
+X-Deepin-DEComponent=true
+X-Deepin-Vendor=deepin


### PR DESCRIPTION
make first dde-file-manager launched by AM

log: as title