### PR TITLE
chore: set systemd services stop timeout to 30s

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-default-settings (2024.05.14) unstable; urgency=medium
+
+  * chore: set systemd services stop timeout to 30s (linuxdeepin/developer-center#8554)
+
+ -- zsien <quezhiyong@deepin.org>  Tue, 14 May 2024 13:31:52 +0800
+
 deepin-default-settings (2024.04.22) unstable; urgency=medium
 
   * Fix #8101

--- a/etc.d/systemd/system.conf.d/timeout-stop-sec.conf
+++ b/etc.d/systemd/system.conf.d/timeout-stop-sec.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultTimeoutStopSec=30s

--- a/etc.d/systemd/user.conf.d/timeout-stop-sec.conf
+++ b/etc.d/systemd/user.conf.d/timeout-stop-sec.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultTimeoutStopSec=30s


### PR DESCRIPTION
设置 systemd service 退出超时为 30s

Issues: linuxdeepin/developer-center#8554