### PR TITLE
fix(etc.d/modprobe.d): drop bt_coex_active=0 option for iwlwifi

### DIFF
--- a/etc.d/modprobe.d/iwlwifi.conf
+++ b/etc.d/modprobe.d/iwlwifi.conf
@@ -1,1 +1,1 @@
-options iwlwifi bt_coex_active=0 power_save=0 swcrypto=0
+options iwlwifi power_save=0 swcrypto=0


### PR DESCRIPTION
This was introduced at least 6 years ago and causes boot errors on devices with newer Intel Wireless cards:

iwlmvm doesn't allow to disable BT Coex, check bt_coex_active module parameter

Drop this antiquated (and probably unneeded version).