### PR TITLE
fix: 修复每次注销或重启后登录到桌面，都会自动打开欢迎界面

### DIFF
--- a/dde-first-run
+++ b/dde-first-run
@@ -47,9 +47,8 @@ if __name__ == "__main__":
             os.makedirs(desktop_path)
         for desktop in desktops:
             desktop_file = path.join("/usr/share/applications", desktop)
-            if path.exists(desktop_file):
+            if path.exists(desktop_file) and os.path.realpath(desktop_file) != os.path.realpath(path.join(desktop_path, desktop)):
                 shutil.copyfile(desktop_file, path.join(desktop_path, desktop))
-
     chrome_config = None
     if not path.exists(path.expanduser('~/.config/google-chrome')):
         if path.exists('/usr/share/deepin-default-settings/google-chrome/override-chrome-config.tar'):


### PR DESCRIPTION
dde-first-run脚本出错,导致不能正常删除autostart

Log: 注销和重启会自动打开欢迎界面
pms: BUG-291879
Change-Id: I023e8be3e38b2f46ba320ec3104ebca7df5a1b7e