### PR TITLE
fix: 通过postinst脚本动态判断版本安装desktop文件

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-default-settings (2024.12.12) unstable; urgency=medium
+
+  * update postinst add _Generate_Icon_manual.
+
+ -- lichenggang <lichenggang@deepin.org>  Thu, 12 Dec 2024 16:30:45 +0800
+
 deepin-default-settings (2024.11.29) unstable; urgency=medium
 
   * Add welcome

--- a/debian/deepin-default-settings.postinst
+++ b/debian/deepin-default-settings.postinst
@@ -97,34 +97,65 @@ do
     fi
 done
 
-case "$ARCH" in
-    x86_64)
-        if [ ! -f /etc/skel/Desktop/org.deepin.browser.desktop ];then
-            if [ -f /var/lib/linglong/entries/share/applications/org.deepin.browser.desktop ];then
-                ln -s /var/lib/linglong/entries/share/applications/org.deepin.browser.desktop /etc/skel/Desktop/org.deepin.browser.desktop || true
+_Generate_Icon_manual () {
+    
+if [ -f /etc/os-version ]; then
+    if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
+        if [ ! -f /etc/skel/Desktop/deepin-manual.desktop ];then
+            if [ -f /usr/share/applications/deepin-manual.desktop ];then
+                ln -s /usr/share/applications/deepin-manual.desktop /etc/skel/Desktop/deepin-manual.desktop || true
             fi
         fi
+    fi
+fi
+
+}
+
+_Generate_Icon_deepin_browser () {
+    
+if [ -f /etc/os-version ]; then
+    if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
+        if [ ! -f /etc/skel/Desktop/org.deepin.browser.desktop ];then
+            if [ -f /var/lib/linglong/entries/share/applications/org.deepin.browser.desktop ];then
+               ln -s /var/lib/linglong/entries/share/applications/org.deepin.browser.desktop /etc/skel/Desktop/org.deepin.browser.desktop || true
+            fi
+        fi
+    fi
+fi
+
+}
+
+_Generate_Icon_firefox () {
+
+if [ -f /etc/os-version ]; then
+    if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
+        if [ ! -f /etc/skel/Desktop/firefox.desktop ];then
+            if [ -f /usr/share/applications/firefox.desktop ];then
+               ln -s /usr/share/applications/firefox.desktop /etc/skel/Desktop/firefox.desktop || true
+            fi
+        fi
+    fi
+fi
+
+}
+
+
+case "$ARCH" in
+    x86_64)
+        _Generate_Icon_deepin_browser
+        _Generate_Icon_manual
         ;;
     loongarch64)
-        if [ ! -f /etc/skel/Desktop/firefox.desktop ];then
-            if [ -f /usr/share/applications/firefox.desktop ];then
-                ln -s /usr/share/applications/firefox.desktop /etc/skel/Desktop/firefox.desktop || true
-            fi  
-        fi
+        _Generate_Icon_firefox
+        _Generate_Icon_manual
         ;;
     riscv64)
-        if [ ! -f /etc/skel/Desktop/firefox.desktop ];then
-            if [ -f /usr/share/applications/firefox.desktop ];then
-                ln -s /usr/share/applications/firefox.desktop /etc/skel/Desktop/firefox.desktop || true 
-            fi   
-        fi
+        _Generate_Icon_firefox
+        _Generate_Icon_manual
         ;;
     aarch64)
-        if [ ! -f /etc/skel/Desktop/firefox.desktop ];then
-            if [ -f /usr/share/applications/firefox.desktop ];then
-                ln -s /usr/share/applications/firefox.desktop /etc/skel/Desktop/firefox.desktop || true 
-            fi  
-        fi
+        _Generate_Icon_firefox
+        _Generate_Icon_manual
         ;;
     *)
         echo "Unknown architecture: $ARCH"

--- a/skel/Desktop/deepin-manual.desktop
+++ b/skel/Desktop/deepin-manual.desktop
@@ -1,1 +1,0 @@
-/usr/share/applications/deepin-manual.desktop


### PR DESCRIPTION
       专业版不需要这些图标在桌面 仅社区版生效

Log:   解决专业版桌面环境默认多deepin-manual图标问题
pms: BUG-293199