### PR TITLE
chore: bump default-settings version to 2025.02.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-default-settings (2025.02.24) unstable; urgency=medium
+
+  * Update launchpad config to ensure fullscreen launcher fill all items
+  * drop bt_coex_active=0 option for iwlwifi
+
+ -- Wang Zichong <wangzichong@deepin.org>  Mon, 24 Feb 2025 11:47:00 +0800
+
 deepin-default-settings (2024.12.13) unstable; urgency=medium
 
   * update postinst.


### PR DESCRIPTION
Changelog:

  * Update launchpad config to ensure fullscreen launcher fill all items
  * drop bt_coex_active=0 option for iwlwifi
