### PR TITLE
feat: increase inotify.max_user_instances to 1024

### DIFF
--- a/sysctl.d/00-deepin.conf
+++ b/sysctl.d/00-deepin.conf
@@ -1,2 +1,5 @@
 # VM Tuning
 vm.max_map_count=262144
+# inotify
+fs.inotify.max_user_instances=1024
+


### PR DESCRIPTION
Applications like IDEs and file watchers may hit "Too many open files" under heavy inotify usage scenarios.

Log: