### PR TITLE
chore: update shortcuts on Desktop after system installation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-default-settings (2025.06.17) unstable; urgency=medium
+
+  * adjust default shortcuts on desktop.
+
+ -- Wang Zichong <wangzichong@deepin.org>  Tue, 17 Jun 2025 14:21:00 +0800
+
 deepin-default-settings (2025.06.11) unstable; urgency=medium
 
   * deepin-manual deb to linglong.
@@ -139,14 +145,14 @@ deepin-default-settings (2020.12.17-1) unstable; urgency=medium
 deepin-default-settings (2020.12.15-1) unstable; urgency=medium
 
   * update 11n_disable=8 -> 11n_disable=1.
-   
+
 
  -- system-dev <system-dev@uniontech.com>  Tue, 15 Dec 2020 13:45:04 +0800
 
 deepin-default-settings (2020.12.07-1) unstable; urgency=medium
 
   * update 11n_disable=1 -> 11n_disable=8.
-  
+
 
  -- system-dev <system-dev@uniontech.com>  Mon, 07 Dec 2020 11:01:57 +0800
 
@@ -1932,4 +1938,3 @@ deepin-default-settings (1.0.2) maverick; urgency=low
   * Cairo Dock config updated.
 
  -- Leng Ganghua <hiweed@gmail.com>  Wed,  13 Oct 2010 20:45:00 +0800
-

--- a/debian/deepin-default-settings.postinst
+++ b/debian/deepin-default-settings.postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script 
+# postinst script
 # see: dh_installdeb(1)
 #DEBHELPER#
 
@@ -14,7 +14,7 @@ case "$1" in
 
         if [ -f /etc/skel/.bashrc ]; then
             sed -i '/#\ Set\ LS_COLORS\ environment/,+5d' /etc/skel/.bashrc
-            cat >> /etc/skel/.bashrc << EOF 
+            cat >> /etc/skel/.bashrc << EOF
 # Set LS_COLORS environment by Deepin
 if [[ ("\$TERM" = *256color || "\$TERM" = screen* || "\$TERM" = xterm* ) && -f /etc/lscolor-256color ]]; then
     eval \$(dircolors -b /etc/lscolor-256color)
@@ -41,7 +41,7 @@ EOF
 
     ;;
     triggered)
-    
+
     if [ -f /opt/cxoffice/etc/cxoffice.conf ]; then
         sed -i "s#;;\(\"AntiVirusScan\" = \)\"\"#\1\"never\"#" /opt/cxoffice/etc/cxoffice.conf
         date
@@ -98,7 +98,7 @@ do
 done
 
 _Generate_Icon_manual () {
-    
+
 if [ -f /etc/os-version ]; then
     if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
         if [ ! -f /etc/skel/Desktop/deepin-manual.desktop ];then
@@ -111,52 +111,21 @@ fi
 
 }
 
-_Generate_Icon_deepin_browser () {
-    
-if [ -f /etc/os-version ]; then
-    if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
-        if [ ! -f /etc/skel/Desktop/org.deepin.browser.desktop ];then
-            ln -s /var/lib/linglong/entries/share/applications/org.deepin.browser.desktop /etc/skel/Desktop/org.deepin.browser.desktop || true
-        fi
-    fi
-fi
-
-}
-
-_Generate_Icon_firefox () {
-
-if [ -f /etc/os-version ]; then
-    if [ "$(cat /etc/os-version) | grep -iq "Community" " ]; then
-        if [ ! -f /etc/skel/Desktop/firefox.desktop ];then
-            if [ -f /usr/share/applications/firefox.desktop ];then
-               ln -s /usr/share/applications/firefox.desktop /etc/skel/Desktop/firefox.desktop || true
-            fi
-        fi
-    fi
-fi
-
-}
-
-
 
 
 
 if [ "$1" = "configure" ] && [ "$2" = "" ]; then
     case "$ARCH" in
         x86_64)
-            _Generate_Icon_deepin_browser
             _Generate_Icon_manual
             ;;
         loongarch64)
-            _Generate_Icon_firefox
             _Generate_Icon_manual
             ;;
         riscv64)
-            _Generate_Icon_firefox
             _Generate_Icon_manual
             ;;
         aarch64)
-            _Generate_Icon_firefox
             _Generate_Icon_manual
             ;;
         *)

--- a/skel/Desktop/dde-trash.desktop
+++ b/skel/Desktop/dde-trash.desktop
@@ -1,0 +1,1 @@
+/usr/share/applications/dde-trash.desktop


### PR DESCRIPTION
更新安装完系统后，默认桌面上包含的快捷方式.

变更：

1. 桌面不再默认包含浏览器的快捷方式
2. 添加回收站快捷方式